### PR TITLE
bugfix: fixing dependency cycle

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,7 +112,6 @@ class arc_ce (
     }
     Class['arc_ce::repositories'] -> Class[Arc_ce::Install]
     Class['arc_ce::repositories'] -> Package[nordugrid-arc-compute-element]
-    Class['arc_ce::repositories'] -> Yumrepo['EGI-trustanchors']
   }
 
   class { 'arc_ce::install':  }


### PR DESCRIPTION
Fixing a circular dependency:

```
Error: Could not apply complete catalog: Found 1 dependency cycle:
(Class[Arc_ce::Repositories] => Yumrepo[EGI-trustanchors] => Class[Arc_ce::Repositories])
Cycle graph written to /var/lib/puppet/state/graphs/cycles.dot.
```
